### PR TITLE
Fix: broken after detached from layout and attached again

### DIFF
--- a/sortable-layout/src/main/java/org/vaadin/jchristophe/SortableLayout.java
+++ b/sortable-layout/src/main/java/org/vaadin/jchristophe/SortableLayout.java
@@ -6,6 +6,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.shared.Registration;
 import elemental.json.JsonArray;
 
@@ -102,8 +103,14 @@ public class SortableLayout extends Div {
     }
 
     private void runBeforeClientResponse(SerializableConsumer<UI> command) {
-        layout.getElement().getNode().runWhenAttached(ui -> ui
-                .beforeClientResponse(layout, context -> command.accept(ui)));
+        final Runnable runnable = () -> getUI()
+                .ifPresent(ui -> ui.beforeClientResponse(layout, context -> command.accept(ui)));
+        final StateNode node = layout.getElement().getNode();
+        if (node.isAttached()) {
+            runnable.run();
+        } else {
+            node.addAttachListener(runnable::run);
+        }
     }
 
     public boolean isDisabledSort() {


### PR DESCRIPTION
The SortableLayout is broken, if it is removed from the layout and added again. 
The `initLazy` client-side function must be called every time the SortableLayout is attached and not only the first time.